### PR TITLE
Add ability to select a parent node when placing scenes

### DIFF
--- a/addons/SceneBuilder/scene_builder_dock.gd
+++ b/addons/SceneBuilder/scene_builder_dock.gd
@@ -28,6 +28,7 @@ var btn_use_surface_normal: CheckButton
 var btn_surface_normal_x: CheckBox
 var btn_surface_normal_y: CheckBox
 var btn_surface_normal_z: CheckBox
+var btn_parent_node_selector: Button
 var btn_group_surface_orientation: ButtonGroup
 var btn_find_world_3d: Button
 var btn_reload_all_items: Button
@@ -67,6 +68,7 @@ var selected_item: SceneBuilderItem = null
 var selected_item_name: String = ""
 var preview_instance: Node3D = null
 var preview_instance_rid_array: Array[RID] = []
+var selected_parent_node: Node3D = null
 
 enum TransformMode {
 	NONE,
@@ -136,10 +138,12 @@ func _enter_tree() -> void:
 		btns_collection_tabs.append(tab_button)
 
 	# Options tab
-	btn_use_surface_normal = scene_builder_dock.get_node("Settings/Tab/Options/SurfaceNormal/UseSurfaceNormal")
-	btn_surface_normal_x = scene_builder_dock.get_node("Settings/Tab/Options/SurfaceNormal/Oritentation/ButtonGroup/X")
-	btn_surface_normal_y = scene_builder_dock.get_node("Settings/Tab/Options/SurfaceNormal/Oritentation/ButtonGroup/Y")
-	btn_surface_normal_z = scene_builder_dock.get_node("Settings/Tab/Options/SurfaceNormal/Oritentation/ButtonGroup/Z")
+	btn_use_surface_normal = scene_builder_dock.get_node("%UseSurfaceNormal")
+	btn_surface_normal_x = scene_builder_dock.get_node("%Oritentation/ButtonGroup/X")
+	btn_surface_normal_y = scene_builder_dock.get_node("%Oritentation/ButtonGroup/Y")
+	btn_surface_normal_z = scene_builder_dock.get_node("%Oritentation/ButtonGroup/Z")
+	btn_parent_node_selector = scene_builder_dock.get_node("%ParentNodeSelector")
+	btn_parent_node_selector.path_selected.connect(set_parent_node)
 	#
 	btn_group_surface_orientation = ButtonGroup.new()
 	btn_surface_normal_x.button_group = btn_group_surface_orientation
@@ -436,6 +440,31 @@ func on_item_icon_clicked(_button_name: String) -> void:
 	elif selected_item_name != _button_name:
 		select_item(selected_collection_name, _button_name)
 
+func set_parent_node(node_path: NodePath) -> void:
+	if not node_path:
+		selected_parent_node = null
+		btn_parent_node_selector.set_node_info(null, null)
+		return
+
+	if not scene_root and not update_world_3d():
+			return
+
+	selected_parent_node = scene_root.get_node(node_path)
+	if not selected_parent_node:
+		btn_parent_node_selector.set_node_info(null, null)
+		printerr("[SceneBuilderDock] ", node_path, " not found in scene")
+		return
+
+	var node_name := selected_parent_node.get_class().split(".")[-1]
+	var node_icon := get_editor_interface().get_base_control().get_theme_icon(node_name, "EditorIcons")
+
+	# if there's an invalid icon, we use the default node icon
+	if node_icon == get_editor_interface().get_base_control().get_theme_icon("invalid icon", "EditorIcons"):
+		node_icon = get_editor_interface().get_base_control().get_theme_icon("Node", "EditorIcons")
+
+	btn_parent_node_selector.set_node_info(selected_parent_node, node_icon)
+	print("[SceneBuilderDock] Parent node set to ", selected_parent_node.name)
+
 func reload_all_items() -> void:
 	print("[SceneBuilderDock] Freeing all texture buttons")
 	for i in range(1, num_collections + 1):
@@ -668,7 +697,10 @@ func instantiate_selected_item_at_position() -> void:
 
 	if result and result.collider:
 		var instance = get_instance_from_path(selected_item.uid)
-		scene_root.add_child(instance)
+		if selected_parent_node:
+			selected_parent_node.add_child(instance)
+		else:
+			scene_root.add_child(instance)
 		instance.owner = scene_root
 		initialize_node_name(instance, selected_item.item_name)
 

--- a/addons/SceneBuilder/scene_builder_dock.gd
+++ b/addons/SceneBuilder/scene_builder_dock.gd
@@ -116,8 +116,6 @@ func _enter_tree() -> void:
 	btn_use_local_space = _hboxcontainer11486.get_child(13)
 	if !btn_use_local_space:
 		printerr("[SceneBuilderDock] Unable to find use local space button")
-	
-	update_world_3d()
 
 	#region Initialize controls for the SceneBuilderDock
 	
@@ -139,11 +137,18 @@ func _enter_tree() -> void:
 
 	# Options tab
 	btn_use_surface_normal = scene_builder_dock.get_node("%UseSurfaceNormal")
-	btn_surface_normal_x = scene_builder_dock.get_node("%Oritentation/ButtonGroup/X")
-	btn_surface_normal_y = scene_builder_dock.get_node("%Oritentation/ButtonGroup/Y")
-	btn_surface_normal_z = scene_builder_dock.get_node("%Oritentation/ButtonGroup/Z")
+	btn_surface_normal_x = scene_builder_dock.get_node("%Orientation/ButtonGroup/X")
+	btn_surface_normal_y = scene_builder_dock.get_node("%Orientation/ButtonGroup/Y")
+	btn_surface_normal_z = scene_builder_dock.get_node("%Orientation/ButtonGroup/Z")
+	
 	btn_parent_node_selector = scene_builder_dock.get_node("%ParentNodeSelector")
-	btn_parent_node_selector.path_selected.connect(set_parent_node)
+	var script_path = SceneBuilderToolbox.find_resource_with_dynamic_path("scene_builder_node_path_selector.gd")
+	if script_path != "":
+		btn_parent_node_selector.set_script(load(script_path))
+		btn_parent_node_selector.path_selected.connect(set_parent_node)
+	else:
+		printerr("[SceneBuilderDock] Failed to find scene_builder_node_path_selector.gd")
+	
 	#
 	btn_group_surface_orientation = ButtonGroup.new()
 	btn_surface_normal_x.button_group = btn_group_surface_orientation
@@ -174,6 +179,7 @@ func _enter_tree() -> void:
 
 	#
 	reload_all_items()
+	update_world_3d()
 
 func _exit_tree() -> void:
 	remove_control_from_docks(scene_builder_dock)
@@ -183,8 +189,8 @@ func _process(_delta: float) -> void:
 	# Update preview item position
 	if placement_mode_enabled:
 
-		if not scene_root or not scene_root is Node3D:
-			print("[SceneBuilderDock] Edited scene root must be of type Node3D, deselecting item")
+		if not scene_root or not scene_root is Node3D or not scene_root.is_inside_tree():
+			print("[SceneBuilderDock] Scene root invalid, ending placement mode")
 			end_placement_mode()
 			return
 
@@ -441,18 +447,30 @@ func on_item_icon_clicked(_button_name: String) -> void:
 		select_item(selected_collection_name, _button_name)
 
 func set_parent_node(node_path: NodePath) -> void:
-	if not node_path:
-		selected_parent_node = null
-		btn_parent_node_selector.set_node_info(null, null)
-		return
-
 	if not scene_root and not update_world_3d():
 			return
+	
+	# If no path provided, set to scene root
+	if node_path.is_empty() or str(node_path) == "":
+		selected_parent_node = scene_root
+		if scene_root:
+			var node_name := scene_root.get_class().split(".")[-1]
+			var node_icon := get_editor_interface().get_base_control().get_theme_icon(node_name, "EditorIcons")
+			
+			if node_icon == get_editor_interface().get_base_control().get_theme_icon("invalid icon", "EditorIcons"):
+				node_icon = get_editor_interface().get_base_control().get_theme_icon("Node", "EditorIcons")
+			
+			btn_parent_node_selector.set_node_info(scene_root, node_icon)
+		else:
+			btn_parent_node_selector.set_node_info(null, null)
+		return
 
 	selected_parent_node = scene_root.get_node(node_path)
 	if not selected_parent_node:
-		btn_parent_node_selector.set_node_info(null, null)
-		printerr("[SceneBuilderDock] ", node_path, " not found in scene")
+		# Fall back to scene root if path not found
+		selected_parent_node = scene_root
+		btn_parent_node_selector.set_node_info(scene_root, get_editor_interface().get_base_control().get_theme_icon("Node", "EditorIcons"))
+		printerr("[SceneBuilderDock] ", node_path, " not found in scene, defaulting to scene root")
 		return
 
 	var node_name := selected_parent_node.get_class().split(".")[-1]
@@ -530,19 +548,25 @@ func update_world_3d() -> bool:
 	if new_scene_root != null and new_scene_root is Node3D:
 		if scene_root == new_scene_root:
 			return true
+		end_placement_mode()
 		scene_root = new_scene_root
 		viewport = EditorInterface.get_editor_viewport_3d()
 		world3d = viewport.find_world_3d()
 		physics_space = world3d.direct_space_state
 		camera = viewport.get_camera_3d()
+		# Wait for next frame to ensure scene is fully loaded
+		#await get_tree().process_frame
+		set_parent_node(NodePath())
 		return true
 	else:
 		print("[SceneBuilderDock] Failed to update world 3d")
+		end_placement_mode()
 		scene_root = null
 		viewport = null
 		world3d = null
 		physics_space = null
 		camera = null
+		set_parent_node(NodePath())
 		return false
 
 # ---- Helpers -----------------------------------------------------------------

--- a/addons/SceneBuilder/scene_builder_dock.tscn
+++ b/addons/SceneBuilder/scene_builder_dock.tscn
@@ -1,4 +1,6 @@
-[gd_scene load_steps=2 format=3 uid="uid://18pjyynbqqci"]
+[gd_scene load_steps=3 format=3 uid="uid://18pjyynbqqci"]
+
+[ext_resource type="Script" uid="uid://g0vw44nmg6p1" path="res://addons/SceneBuilder/scene_builder_node_path_selector.gd" id="1_aaeli"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rn2d1"]
 bg_color = Color(0, 0, 0, 1)
@@ -557,39 +559,63 @@ current_tab = 0
 layout_mode = 2
 metadata/_tab_index = 0
 
-[node name="SurfaceNormal" type="HBoxContainer" parent="Settings/Tab/Options"]
+[node name="Top" type="HBoxContainer" parent="Settings/Tab/Options"]
 layout_mode = 2
 
-[node name="UseSurfaceNormal" type="CheckButton" parent="Settings/Tab/Options/SurfaceNormal"]
+[node name="Left" type="VBoxContainer" parent="Settings/Tab/Options/Top"]
+layout_mode = 2
+
+[node name="UseSurfaceNormal" type="CheckButton" parent="Settings/Tab/Options/Top/Left"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Surface normal"
 
-[node name="Oritentation" type="VBoxContainer" parent="Settings/Tab/Options/SurfaceNormal"]
+[node name="ParentNode" type="HBoxContainer" parent="Settings/Tab/Options/Top/Left"]
+layout_mode = 2
+
+[node name="EmptySpace" type="Control" parent="Settings/Tab/Options/Top/Left/ParentNode"]
+custom_minimum_size = Vector2(2, 0)
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Settings/Tab/Options/Top/Left/ParentNode"]
+layout_mode = 2
+text = "Parent node"
+
+[node name="ParentNodeSelector" type="Button" parent="Settings/Tab/Options/Top/Left/ParentNode"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(100, 0)
+layout_mode = 2
+text = "(root)"
+text_overrun_behavior = 3
+script = ExtResource("1_aaeli")
+
+[node name="Oritentation" type="VBoxContainer" parent="Settings/Tab/Options/Top"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Label" type="Label" parent="Settings/Tab/Options/SurfaceNormal/Oritentation"]
+[node name="Label" type="Label" parent="Settings/Tab/Options/Top/Oritentation"]
 layout_mode = 2
 size_flags_horizontal = 4
 text = "Orientation"
 vertical_alignment = 1
 
-[node name="ButtonGroup" type="HBoxContainer" parent="Settings/Tab/Options/SurfaceNormal/Oritentation"]
+[node name="ButtonGroup" type="HBoxContainer" parent="Settings/Tab/Options/Top/Oritentation"]
 layout_mode = 2
 
-[node name="X" type="CheckBox" parent="Settings/Tab/Options/SurfaceNormal/Oritentation/ButtonGroup"]
+[node name="X" type="CheckBox" parent="Settings/Tab/Options/Top/Oritentation/ButtonGroup"]
 layout_mode = 2
 size_flags_horizontal = 6
 text = "X"
 
-[node name="Y" type="CheckBox" parent="Settings/Tab/Options/SurfaceNormal/Oritentation/ButtonGroup"]
+[node name="Y" type="CheckBox" parent="Settings/Tab/Options/Top/Oritentation/ButtonGroup"]
 layout_mode = 2
 size_flags_horizontal = 6
 button_pressed = true
 text = "Y"
 
-[node name="Z" type="CheckBox" parent="Settings/Tab/Options/SurfaceNormal/Oritentation/ButtonGroup"]
+[node name="Z" type="CheckBox" parent="Settings/Tab/Options/Top/Oritentation/ButtonGroup"]
 layout_mode = 2
 size_flags_horizontal = 6
 text = "-Z"

--- a/addons/SceneBuilder/scene_builder_dock.tscn
+++ b/addons/SceneBuilder/scene_builder_dock.tscn
@@ -1,6 +1,4 @@
-[gd_scene load_steps=3 format=3 uid="uid://18pjyynbqqci"]
-
-[ext_resource type="Script" uid="uid://g0vw44nmg6p1" path="res://addons/SceneBuilder/scene_builder_node_path_selector.gd" id="1_aaeli"]
+[gd_scene load_steps=2 format=3 uid="uid://18pjyynbqqci"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rn2d1"]
 bg_color = Color(0, 0, 0, 1)
@@ -588,34 +586,33 @@ custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "(root)"
 text_overrun_behavior = 3
-script = ExtResource("1_aaeli")
 
-[node name="Oritentation" type="VBoxContainer" parent="Settings/Tab/Options/Top"]
+[node name="Orientation" type="VBoxContainer" parent="Settings/Tab/Options/Top"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Label" type="Label" parent="Settings/Tab/Options/Top/Oritentation"]
+[node name="Label" type="Label" parent="Settings/Tab/Options/Top/Orientation"]
 layout_mode = 2
 size_flags_horizontal = 4
 text = "Orientation"
 vertical_alignment = 1
 
-[node name="ButtonGroup" type="HBoxContainer" parent="Settings/Tab/Options/Top/Oritentation"]
+[node name="ButtonGroup" type="HBoxContainer" parent="Settings/Tab/Options/Top/Orientation"]
 layout_mode = 2
 
-[node name="X" type="CheckBox" parent="Settings/Tab/Options/Top/Oritentation/ButtonGroup"]
+[node name="X" type="CheckBox" parent="Settings/Tab/Options/Top/Orientation/ButtonGroup"]
 layout_mode = 2
 size_flags_horizontal = 6
 text = "X"
 
-[node name="Y" type="CheckBox" parent="Settings/Tab/Options/Top/Oritentation/ButtonGroup"]
+[node name="Y" type="CheckBox" parent="Settings/Tab/Options/Top/Orientation/ButtonGroup"]
 layout_mode = 2
 size_flags_horizontal = 6
 button_pressed = true
 text = "Y"
 
-[node name="Z" type="CheckBox" parent="Settings/Tab/Options/Top/Oritentation/ButtonGroup"]
+[node name="Z" type="CheckBox" parent="Settings/Tab/Options/Top/Orientation/ButtonGroup"]
 layout_mode = 2
 size_flags_horizontal = 6
 text = "-Z"

--- a/addons/SceneBuilder/scene_builder_node_path_selector.gd
+++ b/addons/SceneBuilder/scene_builder_node_path_selector.gd
@@ -1,0 +1,37 @@
+@tool
+extends Button
+
+signal path_selected(path: NodePath)
+
+
+func _ready() -> void:
+	pressed.connect(_on_pressed)
+
+
+func _on_pressed() -> void:
+	# pressing the button clears the selection
+	path_selected.emit("")
+
+
+func _can_drop_data(_at_position: Vector2, data: Variant) -> bool:
+	# can only drop if the data is a dictionary with a single node selected
+	return (
+		(typeof(data) == TYPE_DICTIONARY and data.get("type") == "nodes" and data.get("nodes"))
+		and data.get("nodes").size() == 1
+	)
+
+
+func _drop_data(_position: Vector2, data: Variant) -> void:
+	path_selected.emit(data.get("nodes")[0])
+
+
+func set_node_info(node: Node3D, node_icon: Texture2D):
+	# Set the button text to the node name
+	if node:
+		text = node.name
+		tooltip_text = node.name
+		icon = node_icon
+	else:
+		text = "(root)"
+		tooltip_text = ""
+		icon = null

--- a/addons/SceneBuilder/scene_builder_node_path_selector.gd
+++ b/addons/SceneBuilder/scene_builder_node_path_selector.gd
@@ -1,17 +1,15 @@
 @tool
 extends Button
+class_name ParentNodeSelector
 
 signal path_selected(path: NodePath)
-
 
 func _ready() -> void:
 	pressed.connect(_on_pressed)
 
-
 func _on_pressed() -> void:
 	# pressing the button clears the selection
 	path_selected.emit("")
-
 
 func _can_drop_data(_at_position: Vector2, data: Variant) -> bool:
 	# can only drop if the data is a dictionary with a single node selected
@@ -20,10 +18,8 @@ func _can_drop_data(_at_position: Vector2, data: Variant) -> bool:
 		and data.get("nodes").size() == 1
 	)
 
-
 func _drop_data(_position: Vector2, data: Variant) -> void:
 	path_selected.emit(data.get("nodes")[0])
-
 
 func set_node_info(node: Node3D, node_icon: Texture2D):
 	# Set the button text to the node name

--- a/addons/SceneBuilder/scene_builder_node_path_selector.gd.uid
+++ b/addons/SceneBuilder/scene_builder_node_path_selector.gd.uid
@@ -1,0 +1,1 @@
+uid://ciuy3glceywqd


### PR DESCRIPTION
This add a new "Parent node" option in the options tab.

By dragging a node here, you can set that node to be where new instances are placed when they are instantiated.

Clicking on the button will reset the parent node to the root of the scene.

https://github.com/user-attachments/assets/c1028251-568e-48ac-a830-95f975cafdaf

