### PR TITLE
Add "use local space" button to scene builder options to fix crash in Godot 4.6

### DIFF
--- a/addons/scene_builder/scene_builder_dock.gd
+++ b/addons/scene_builder/scene_builder_dock.gd
@@ -26,7 +26,6 @@ var undo_redo: EditorUndoRedoManager
 
 # Godot controls
 var base_control: Control
-var btn_use_local_space: Button
 
 # SceneBuilderDock controls
 var scene_builder_dock: VBoxContainer
@@ -36,6 +35,7 @@ var tab_container: TabContainer  # Current active tab container
 var btns_collection_tabs: Array = []  # Current active buttons (reference to one palette)
 # Options
 var btn_use_surface_normal: CheckButton
+var btn_use_local_space: CheckButton
 var btn_surface_normal_x: CheckBox
 var btn_surface_normal_y: CheckBox
 var btn_surface_normal_z: CheckBox
@@ -132,18 +132,7 @@ func _enter_tree() -> void:
 	editor = get_editor_interface()
 	undo_redo = get_undo_redo()
 	base_control = editor.get_base_control()
-	
-	# Found using: https://github.com/Zylann/godot_editor_debugger_plugin
-	var _panel : Panel = get_editor_interface().get_base_control()
-	var _vboxcontainer15 : VBoxContainer = _panel.get_child(0)
-	var _vboxcontainer26 : VBoxContainer = _vboxcontainer15.get_child(1).get_child(1).get_child(1).get_child(0)
-	var _main_screen : VBoxContainer = _vboxcontainer26.get_child(0).get_child(0).get_child(0).get_child(1).get_child(0)
-	var _hboxcontainer11486 : HBoxContainer = _main_screen.get_child(1).get_child(0).get_child(0).get_child(0)
-	
-	btn_use_local_space = _hboxcontainer11486.get_child(13)
-	if !btn_use_local_space:
-		printerr("[SceneBuilderDock] Unable to find use local space button")
-	
+
 	#region Initialize controls for the SceneBuilderDock
 	
 	var path : String = SceneBuilderToolbox.find_resource_with_dynamic_path("scene_builder_dock.tscn")
@@ -157,6 +146,7 @@ func _enter_tree() -> void:
 	
 	# Options tab
 	btn_use_surface_normal = scene_builder_dock.get_node("%UseSurfaceNormal")
+	btn_use_local_space = scene_builder_dock.get_node("%UseLocalSpace")
 	btn_surface_normal_x = scene_builder_dock.get_node("%Orientation/ButtonGroup/X")
 	btn_surface_normal_y = scene_builder_dock.get_node("%Orientation/ButtonGroup/Y")
 	btn_surface_normal_z = scene_builder_dock.get_node("%Orientation/ButtonGroup/Z")

--- a/addons/scene_builder/scene_builder_dock.tscn
+++ b/addons/scene_builder/scene_builder_dock.tscn
@@ -2809,6 +2809,12 @@ layout_mode = 2
 size_flags_horizontal = 3
 text = "Surface normal"
 
+[node name="UseLocalSpace" type="CheckButton" parent="Settings/Tab/Options/FirstRow/Left"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Use local space"
+
 [node name="Orientation" type="VBoxContainer" parent="Settings/Tab/Options/FirstRow"]
 unique_name_in_owner = true
 layout_mode = 2


### PR DESCRIPTION
Closes #59 

When trying out [Godot 4.6-beta1](https://godotengine.org/article/dev-snapshot-godot-4-6-beta-1/) I noticed that the `scene-builder` add-on errors out and fails to add itself to the dock.

https://github.com/sci-comp/scene-builder/blob/995633142c29723c260d3b123393482c0784b7f4/addons/scene_builder/scene_builder_dock.gd#L136-L141

```
ERROR: res://addons/scene_builder/scene_builder_dock.gd:139 - Trying to assign value of type 'FileSystemDock' to a variable of type 'VBoxContainer'.
```

Likely because of the new default editor theme that was added in Godot 4.6.

---

Finding the "use local space" button in the editor is going to be fragile and is bound to break in future Godot versions; we could try to get this button in a more defensive way but I'm not sure that's worth it.

Adding a specific "Use local space" toggle to the scene builder options seems like an _okay_ compromise here. Ideally, there would be some way added to the engine itself to view/modify the state of the editor inside of a plugin.